### PR TITLE
Fixes `zero`/`negative` TTL behavior and docs. Closes #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+PR_DESCRIPTION.md

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ func main() {
   cache := perch.New[string](1024)
 
   // Reserve memory for the cache (required before use)
-  if err := cache.Reserve(); err != nil {
-    panic(err)
-  }
+  cache.Reserve()
 
   // Define a loader function
   loader := func(ctx context.Context, key string) (string, error) {
@@ -106,14 +104,12 @@ Creates a new Perch cache with the specified capacity in bytes. The actual numbe
 cache := perch.New[string](1024) // 1KB capacity for strings
 ```
 
-### Reserve() error
+### Reserve()
 
 Allocates all the slots required for the cache. **Must be called before the cache is used**. Safe to call multiple times - only allocates once.
 
 ```go
-if err := cache.Reserve(); err != nil {
-  return err
-}
+cache.Reserve()
 ```
 
 ### Get(ctx, key, ttl, loader) (T, bool, error)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ func main() {
   // loader function won't be called again
   fmt.Printf("Value: %s, Cache hit: %t\n", value, hit) // "value-for-my-key", true
 
+  // ttl == 0 pins the value (expires ~99 years later internally)
+  cache.Get(ctx, "pinned-key", 0, loader)
+
+  // ttl < 0 bypasses caching but still shares the loader result
+  value, hit, err = cache.Get(ctx, "live-key", -1, loader)
+  fmt.Printf("Value: %s, Cache hit: %t\n", value, hit) // hit will always be false
+
   // Peek at the value without affecting LRU order
   peekValue, found := cache.Peek("my-key")
   if found {
@@ -76,6 +83,18 @@ func main() {
   }
 }
 ```
+
+## TTL Semantics & Singleflight
+
+Perch accepts any TTL and adapts its behavior:
+
+- `ttl > 0`: cache with the provided expiry
+- `ttl == 0`: cache indefinitely (implemented as a ~99-year expiry) while still respecting LRU eviction
+- `ttl < 0`: bypass caching entirely; the loader still runs once per key thanks to singleflight, and all waiters receive the same result before the entry is evicted
+
+This flexibility makes it easy to mix cached, pinned, and real-time reads while still benefiting from the built-in singleflight protections.
+
+> **Note:** TTL changes take effect only when the loader runs. If a subsequent `Get` call uses a different TTL while the cached value is still fresh, Perch keeps the original expiry until the entry is reloaded (e.g., after it expires, is deleted, or you force a reload with `ttl < 0`). This prevents one caller from unintentionally shortening or lengthening the lifetime chosen by the loader that populated the cache.
 
 ## API Reference
 
@@ -103,7 +122,7 @@ Retrieves a value from the cache. If the value is not present or has expired, th
 
 - `ctx`: Context for cancellation and timeouts
 - `key`: Cache key
-- `ttl`: Time-to-live for the cached value (0 or negative means no caching)
+- `ttl`: Time-to-live for the cached value (`0` caches indefinitely, `ttl < 0` bypasses caching, and TTL changes apply when the loader runs)
 - `loader`: Function to load the value if not in cache
 - Returns: `(value, cacheHit, error)` where `cacheHit` indicates if the value was found in cache
 
@@ -219,13 +238,12 @@ for i := 0; i < 1000; i++ {
 ### Hit Rate Best Practices
 
 1. **Monitor Regularly**: Check hit rates during development and production
-2. **Set Targets**: Aim for hit rates above 80% for most use cases
-3. **Analyze Patterns**: Low hit rates may indicate:
+1. **Set Targets**: Aim for hit rates above 80% for most use cases
+1. **Analyze Patterns**: Low hit rates may indicate:
    - Cache size too small
    - TTL too short
    - Poor access patterns
    - Need for different eviction strategy
-4. **Reset Periodically**: Use `ResetStats()` to monitor performance over specific time periods
 
 ```go
 // Example: Monitor cache performance over time windows
@@ -248,14 +266,16 @@ func monitorCache(cache *perch.Perch[string], duration time.Duration) {
 
 ## Advanced Usage
 
-### Zero TTL (No Caching)
+### Explicit TTL Controls
 
-Pass 0 or negative TTL to disable caching for specific requests:
+Use TTL values to dial in caching semantics per call:
 
 ```go
-// This will always call the loader function
-value, hit, err := cache.Get(ctx, "key", 0, loader)
-// hit will always be false for zero TTL
+// Pin the value indefinitely (subject to LRU eviction when capacity is full)
+cache.Get(ctx, "key", 0, loader)
+
+// Disable caching for this call; the loader still runs once due to singleflight
+value, hit, err := cache.Get(ctx, "key", -1, loader) // hit is always false
 ```
 
 ### Error Handling

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -26,7 +26,7 @@ import (
 // BenchmarkCacheHit benchmarks cache hit performance
 func BenchmarkCacheHit(b *testing.B) {
 	cache := New[string](1600) // 100 * 16 bytes = 1600 bytes
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	key := "benchmark-hit-key"
 	value := "benchmark-hit-value"
@@ -50,7 +50,7 @@ func BenchmarkCacheHit(b *testing.B) {
 // BenchmarkCacheMiss benchmarks cache miss performance
 func BenchmarkCacheMiss(b *testing.B) {
 	cache := New[string](1600) // 100 * 16 bytes = 1600 bytes
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 
@@ -74,7 +74,7 @@ func BenchmarkCacheMiss(b *testing.B) {
 // BenchmarkCacheHitWithAllocationTracking benchmarks cache hits with allocation tracking
 func BenchmarkCacheHitWithAllocationTracking(b *testing.B) {
 	cache := New[string](1600) // 100 * 16 bytes = 1600 bytes
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	key := "allocation-hit-key"
 	value := "allocation-hit-value"
@@ -107,7 +107,7 @@ func BenchmarkCacheHitWithAllocationTracking(b *testing.B) {
 // BenchmarkPeek benchmarks Peek operation performance
 func BenchmarkPeek(b *testing.B) {
 	cache := New[string](1600) // 100 * 16 bytes = 1600 bytes
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	key := "peek-key"
 	value := "peek-value"
@@ -131,7 +131,7 @@ func BenchmarkPeek(b *testing.B) {
 // BenchmarkDelete benchmarks Delete operation performance
 func BenchmarkDelete(b *testing.B) {
 	cache := New[string](1600) // 100 * 16 bytes = 1600 bytes
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 
@@ -159,7 +159,7 @@ func BenchmarkDelete(b *testing.B) {
 // BenchmarkConcurrentAccess benchmarks concurrent access patterns
 func BenchmarkConcurrentAccess(b *testing.B) {
 	cache := New[string](1600) // 100 * 16 bytes = 1600 bytes
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 	numKeys := 10
@@ -189,7 +189,7 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 // BenchmarkLRUEviction benchmarks LRU eviction performance
 func BenchmarkLRUEviction(b *testing.B) {
 	cache := New[string](160) // 10 * 16 bytes = 160 bytes, small cache to force evictions
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 
@@ -222,7 +222,7 @@ func BenchmarkDifferentSizes(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(size.name, func(b *testing.B) {
 			cache := New[string](size.bytes)
-			_ = cache.Reserve()
+			cache.Reserve()
 
 			ttl := 5 * time.Minute
 			loader := func(ctx context.Context, k string) (string, error) {
@@ -247,7 +247,7 @@ func BenchmarkDifferentDataTypes(b *testing.B) {
 	// String cache
 	b.Run("String", func(b *testing.B) {
 		cache := New[string](1600)
-		_ = cache.Reserve()
+		cache.Reserve()
 
 		ttl := 5 * time.Minute
 		loader := func(ctx context.Context, k string) (string, error) {
@@ -268,7 +268,7 @@ func BenchmarkDifferentDataTypes(b *testing.B) {
 	// Int cache
 	b.Run("Int", func(b *testing.B) {
 		cache := New[int](1600)
-		_ = cache.Reserve()
+		cache.Reserve()
 
 		ttl := 5 * time.Minute
 		loader := func(ctx context.Context, k string) (int, error) {
@@ -295,7 +295,7 @@ func BenchmarkDifferentDataTypes(b *testing.B) {
 
 	b.Run("Struct", func(b *testing.B) {
 		cache := New[TestStruct](1600)
-		_ = cache.Reserve()
+		cache.Reserve()
 
 		ttl := 5 * time.Minute
 		loader := func(ctx context.Context, k string) (TestStruct, error) {
@@ -321,7 +321,7 @@ func BenchmarkDifferentDataTypes(b *testing.B) {
 // BenchmarkTTLExpiration benchmarks TTL expiration handling
 func BenchmarkTTLExpiration(b *testing.B) {
 	cache := New[string](1600)
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	shortTTL := 1 * time.Millisecond
 	longTTL := 5 * time.Minute
@@ -353,7 +353,7 @@ func BenchmarkTTLExpiration(b *testing.B) {
 // BenchmarkZeroTTL benchmarks zero TTL (no caching) performance
 func BenchmarkZeroTTL(b *testing.B) {
 	cache := New[string](1600)
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	loader := func(ctx context.Context, k string) (string, error) {
 		time.Sleep(1 * time.Microsecond) // Simulate work
@@ -374,7 +374,7 @@ func BenchmarkZeroTTL(b *testing.B) {
 // BenchmarkSingleflight benchmarks singleflight behavior
 func BenchmarkSingleflight(b *testing.B) {
 	cache := New[string](1600)
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	key := "singleflight-key"
 	value := "singleflight-value"
@@ -405,7 +405,7 @@ func BenchmarkSingleflight(b *testing.B) {
 // BenchmarkMemoryUsage benchmarks memory usage patterns
 func BenchmarkMemoryUsage(b *testing.B) {
 	cache := New[string](1600)
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 	loader := func(ctx context.Context, k string) (string, error) {
@@ -432,7 +432,7 @@ func BenchmarkMemoryUsage(b *testing.B) {
 // BenchmarkHitRateCalculation benchmarks hit rate calculation performance
 func BenchmarkHitRateCalculation(b *testing.B) {
 	cache := New[string](1600)
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 	loader := func(ctx context.Context, k string) (string, error) {
@@ -460,7 +460,7 @@ func BenchmarkHitRateCalculation(b *testing.B) {
 // BenchmarkStatsCalculation benchmarks stats calculation performance
 func BenchmarkStatsCalculation(b *testing.B) {
 	cache := New[string](1600)
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 	loader := func(ctx context.Context, k string) (string, error) {
@@ -488,7 +488,7 @@ func BenchmarkStatsCalculation(b *testing.B) {
 // BenchmarkConcurrentMixedOperations benchmarks mixed concurrent operations
 func BenchmarkConcurrentMixedOperations(b *testing.B) {
 	cache := New[string](1600)
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 	loader := func(ctx context.Context, k string) (string, error) {
@@ -527,7 +527,7 @@ func BenchmarkConcurrentMixedOperations(b *testing.B) {
 // BenchmarkCacheReset benchmarks cache reset performance
 func BenchmarkCacheReset(b *testing.B) {
 	cache := New[string](1600)
-	_ = cache.Reserve()
+	cache.Reserve()
 
 	ttl := 5 * time.Minute
 	loader := func(ctx context.Context, k string) (string, error) {

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -42,7 +42,7 @@ func (s *ConcurrencyTestSuite) SetupSuite() {
 func (s *ConcurrencyTestSuite) BeforeTest(suiteName, testName string) {
 	slog.Info("BeforeTest start", "TestSuite", "ConcurrencyTestSuite", "TestName", testName)
 	s.cache = New[string](160) // 10 * 16 bytes = 160 bytes
-	_ = s.cache.Reserve()      // Allocate slots
+	s.cache.Reserve()          // Allocate slots
 }
 
 // AfterTest runs after each test
@@ -318,7 +318,7 @@ func (s *ConcurrencyTestSuite) TestConcurrentExpiration() {
 // TestConcurrentLRUEviction tests concurrent access during LRU eviction
 func (s *ConcurrencyTestSuite) TestConcurrentLRUEviction() {
 	cache := New[string](48) // 3 * 16 bytes = 48 bytes, small capacity to force eviction
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	// Load initial items

--- a/hitrate_test.go
+++ b/hitrate_test.go
@@ -38,7 +38,7 @@ func (s *HitRateTestSuite) SetupSuite() {
 func (s *HitRateTestSuite) BeforeTest(suiteName, testName string) {
 	slog.Info("BeforeTest start", "TestSuite", "HitRateTestSuite", "TestName", testName)
 	s.cache = New[string](160) // 10 * 16 bytes = 160 bytes
-	_ = s.cache.Reserve()      // Allocate slots
+	s.cache.Reserve()          // Allocate slots
 }
 
 // AfterTest runs after each test

--- a/lru_test.go
+++ b/lru_test.go
@@ -53,7 +53,7 @@ func (s *LRUTestSuite) TearDownSuite() {
 // TestBasicLRUEviction tests basic LRU eviction
 func (s *LRUTestSuite) TestBasicLRUEviction() {
 	cache := New[string](48) // 3 * 16 bytes = 48 bytes
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	// Create loaders for different keys
@@ -102,7 +102,7 @@ func (s *LRUTestSuite) TestBasicLRUEviction() {
 // TestLRUAccessOrder tests that access order affects eviction
 func (s *LRUTestSuite) TestLRUAccessOrder() {
 	cache := New[string](48) // 3 * 16 bytes = 48 bytes
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	loaders := map[string]func(context.Context, string) (string, error){
@@ -148,7 +148,7 @@ func (s *LRUTestSuite) TestLRUAccessOrder() {
 // TestLRUWithExpiration tests LRU behavior with expiration
 func (s *LRUTestSuite) TestLRUWithExpiration() {
 	cache := New[string](48) // 3 * 16 bytes = 48 bytes
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	shortTTL := 20 * time.Millisecond
 	longTTL := 5 * time.Minute
 
@@ -195,7 +195,7 @@ func (s *LRUTestSuite) TestLRUWithExpiration() {
 // TestLRUDelete tests LRU behavior with deletion
 func (s *LRUTestSuite) TestLRUDelete() {
 	cache := New[string](48) // 3 * 16 bytes = 48 bytes
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	loaders := map[string]func(context.Context, string) (string, error){
@@ -240,7 +240,7 @@ func (s *LRUTestSuite) TestLRUDelete() {
 // TestLRUConcurrentAccess tests concurrent access affecting LRU order
 func (s *LRUTestSuite) TestLRUConcurrentAccess() {
 	cache := New[string](48) // 3 * 16 bytes = 48 bytes
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	// Load initial items
@@ -302,7 +302,7 @@ func (s *LRUTestSuite) TestLRUConcurrentAccess() {
 func (s *LRUTestSuite) TestLRUEdgeCases() {
 	// Test with capacity 1
 	cache1 := New[string](16) // 1 * 16 bytes = 16 bytes
-	_ = cache1.Reserve()      // Allocate slots
+	cache1.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	_, _, err := cache1.Get(s.T().Context(), "key1", ttl, func(ctx context.Context, k string) (string, error) {
@@ -325,7 +325,7 @@ func (s *LRUTestSuite) TestLRUEdgeCases() {
 
 	// Test with capacity 2
 	cache2 := New[string](32) // 2 * 16 bytes = 32 bytes
-	_ = cache2.Reserve()      // Allocate slots
+	cache2.Reserve()          // Allocate slots
 
 	// Load same key multiple times
 	for i := 0; i < 5; i++ {
@@ -343,7 +343,7 @@ func (s *LRUTestSuite) TestLRUEdgeCases() {
 // TestLRUPeekBehavior tests that Peek doesn't affect LRU order
 func (s *LRUTestSuite) TestLRUPeekBehavior() {
 	cache := New[string](48) // 3 * 16 bytes = 48 bytes
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	// Load 3 items

--- a/perch_test.go
+++ b/perch_test.go
@@ -144,15 +144,19 @@ func (s *PerchTestSuite) TestZeroTTL() {
 		return value, nil
 	}
 
-	// Multiple calls with zero TTL should all call the loader
+	// Multiple calls with TTL=0 (indefinite caching) should only call loader once
 	for i := 0; i < 3; i++ {
 		result, hit, err := s.cache.Get(s.T().Context(), key, 0, loader)
 		s.NoError(err)
-		s.False(hit, "Zero TTL should always be a cache miss")
+		if i == 0 {
+			s.False(hit, "First call with TTL=0 should be a cache miss")
+		} else {
+			s.True(hit, "Subsequent calls with TTL=0 should be cache hits")
+		}
 		s.Equal(value, result)
 	}
 
-	s.Equal(3, callCount, "Loader should be called for each request with zero TTL")
+	s.Equal(1, callCount, "Loader should be called only once with TTL=0 (indefinite caching)")
 }
 
 // TestDelete tests the Delete functionality

--- a/perch_test.go
+++ b/perch_test.go
@@ -41,7 +41,7 @@ func (s *PerchTestSuite) BeforeTest(suiteName, testName string) {
 	slog.Info("BeforeTest start", "TestSuite", "PerchTestSuite", "TestName", testName)
 	// Create a fresh cache for each test - enough bytes for 10 string entries
 	s.cache = New[string](160) // 10 * 16 bytes = 160 bytes
-	_ = s.cache.Reserve()      // Allocate slots
+	s.cache.Reserve()          // Allocate slots
 }
 
 // AfterTest runs after each test
@@ -68,8 +68,7 @@ func (s *PerchTestSuite) TestNew() {
 	s.Equal(0, len(cache.slots)) // starts empty before Reserve()
 
 	// Reserve slots
-	err := cache.Reserve()
-	s.NoError(err)
+	cache.Reserve()
 	s.Equal(6, len(cache.slots)) // capacity + 1 for 1-based indexing, allocated after Reserve()
 
 	// Test panic on invalid capacity
@@ -223,7 +222,7 @@ func (s *PerchTestSuite) TestPeek() {
 func (s *PerchTestSuite) TestLRUEviction() {
 	// Create cache with small capacity - 2 string entries
 	cache := New[string](32) // 2 * 16 bytes = 32 bytes
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	// Load 3 items (exceeds capacity)
@@ -411,7 +410,7 @@ func (s *PerchTestSuite) TestEdgeCases() {
 func (s *PerchTestSuite) TestMoveToFront() {
 	// Create cache with capacity 2 - 2 string entries
 	cache := New[string](32) // 2 * 16 bytes = 32 bytes
-	_ = cache.Reserve()      // Allocate slots
+	cache.Reserve()          // Allocate slots
 	ttl := 5 * time.Minute
 
 	// Load two items

--- a/performance_test.go
+++ b/performance_test.go
@@ -40,7 +40,7 @@ func (s *PerformanceTestSuite) SetupSuite() {
 func (s *PerformanceTestSuite) BeforeTest(suiteName, testName string) {
 	slog.Info("BeforeTest start", "TestSuite", "PerformanceTestSuite", "TestName", testName)
 	s.cache = New[string](1600) // 100 * 16 bytes = 1600 bytes for performance testing
-	_ = s.cache.Reserve()       // Allocate slots
+	s.cache.Reserve()           // Allocate slots
 }
 
 // AfterTest runs after each test
@@ -147,7 +147,7 @@ func (s *PerformanceTestSuite) TestCacheMissPerformance() {
 // TestLRUEvictionPerformance tests the performance of LRU eviction
 func (s *PerformanceTestSuite) TestLRUEvictionPerformance() {
 	cache := New[string](160) // 10 * 16 bytes = 160 bytes, small cache to force evictions
-	_ = cache.Reserve()       // Allocate slots
+	cache.Reserve()           // Allocate slots
 	ttl := 5 * time.Minute
 
 	loader := func(ctx context.Context, k string) (string, error) {

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -39,7 +39,7 @@ func (s *TTLTestSuite) SetupSuite() {
 func (s *TTLTestSuite) BeforeTest(suiteName, testName string) {
 	slog.Info("BeforeTest start", "TestSuite", "TTLTestSuite", "TestName", testName)
 	s.cache = New[string](160) // 10 * 16 bytes = 160 bytes
-	_ = s.cache.Reserve()      // Allocate slots
+	s.cache.Reserve()          // Allocate slots
 }
 
 // AfterTest runs after each test

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -141,14 +141,14 @@ func (s *TTLTestSuite) TestZeroTTL() {
 		return value, nil
 	}
 
-	// Multiple calls with zero TTL should all call loader
+	// Multiple calls with TTL=0 (indefinite caching) should only call loader once
 	for i := 0; i < 5; i++ {
 		result, _, err := s.cache.Get(s.T().Context(), key, 0, loader)
 		s.NoError(err)
 		s.Equal(value, result)
 	}
 
-	s.Equal(5, callCount, "Should call loader for each zero TTL request")
+	s.Equal(1, callCount, "Should call loader only once with TTL=0 (indefinite caching)")
 }
 
 // TestNegativeTTL tests negative TTL behavior


### PR DESCRIPTION
Align runtime behavior, tests, and docs so `ttl == 0` truly pins entries while `ttl < 0` bypasses caching but still benefits from singleflight, and make sure users understand when TTL changes take effect.

Updating `Reserve()` to not return error. It was always returning `nil` anyway